### PR TITLE
Fix windows C++20 build error

### DIFF
--- a/src/tint/lang/spirv/writer/raise/shader_io.cc
+++ b/src/tint/lang/spirv/writer/raise/shader_io.cc
@@ -101,7 +101,7 @@ struct StateImpl : core::ir::transform::ShaderIOBackendState {
                 if (func->Stage() == core::ir::Function::PipelineStage::kFragment &&
                     addrspace == core::AddressSpace::kIn &&
                     io.type->is_integer_scalar_or_vector()) {
-                    io.attributes.interpolation = {core::InterpolationType::kFlat};
+                    io.attributes.interpolation = core::Interpolation{core::InterpolationType::kFlat};
                 }
             }
             if (io.attributes.location) {


### PR DESCRIPTION
This PR fixes a C++20 windows build error in dawn.

The upstream repo is not yet being built with C++20 ([see this issue](https://issues.chromium.org/issues/343500108)). From eyeballing the code, I don't think the build error we're seeing is addressed in recent upstream commits. Rather than attempt to update dawn to the latest version of the upstream branch which likely doesn't fix this problem, I've elected to put in a simple fix for our immediate C++20 build problem.

Here's the [original error](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-windows/1001/consoleFull):

```
12:36:13 C:\workspace\3rdparty\dawn\src\tint\lang\spirv\writer\raise\shader_io.cc(104,51): error C2664: 'std::optional<tint::core::Interpolation> &std::optional<tint::core::Interpolation>::operator =(std::optional<tint::core::Interpolation> &&)': cannot convert argument 1 from 'initializer list' to 'std::optional<tint::core::Interpolation> &&' [C:\workspace\3rdparty\dawn\dawn.vcxproj]
```

**vTest**

Built as C++20: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1036/downstreambuildview/
Built as C++17: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1037/downstreambuildview/