### PR TITLE
arch: Use \Ob2 instead of \Ob3 for dawn test builds

### DIFF
--- a/dawn.lua
+++ b/dawn.lua
@@ -1077,13 +1077,7 @@ if (_PLATFORM_WINDOWS) then
   configuration { "Test" }
 
   buildoptions {
-    "/GL", -- Enable whole program optimizations
-    "/Gw", -- Optimize Global Data
-    -- "/Ob3" is already on for Test builds
-    "/wd4701", -- Silences potentially uninitialized local variable warning which causes errors during LTCG
-    "/wd4702", -- Silences an unreachable code warning which causes errors during LTCG
-    "/wd4706", -- Silences assignment within conditional expression warning which causes errors during LTCG
-    "/wd4740", -- Silences flow in or out of inline asm code suppresses global optimization errors during LTCG
+    "/Ob2"
   }
 
 end


### PR DESCRIPTION
For issue: https://devtopia.esri.com/runtime/vital-spark/issues/139

[3rdparty vTest (all triplets)](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1150/downstreambuildview/)
[RTC vTest, test build, primary triplets, and some tests, incl c_api_framework_tests](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/27598/downstreambuildview/)