### PR TITLE
arch: Update abseil-cpp

### DIFF
--- a/dawn.lua
+++ b/dawn.lua
@@ -114,6 +114,7 @@ end
 
 defines {
   "DAWN_NATIVE_IMPLEMENTATION",
+  "STRIP_LOG=1", -- Prevent abseil-cpp making restricted windows calls for stack tracing
   "TINT_BUILD_WGSL_READER=1",
   "TINT_BUILD_WGSL_WRITER=1",
 }
@@ -139,7 +140,7 @@ includedirs {
 -- to the same output location. One will overwrite the other.
 --
 --   "src/tint/lang/core/ir/function.cc",
---   "src/tint/lang/wgsl/ast/function_rtc_shim1.cc",
+--   "src/tint/lang/wgsl/ast/function.cc",
 --
 -- To remedy this, the runtimecore branch introduces "shim" files with
 -- unique names which simply include the original. We build the shim file


### PR DESCRIPTION
For issue: https://devtopia.esri.com/runtime/vital-spark/issues/215

This PR sets the STRIP_LOG preprocessor symbol to ensure that it includes abseil headers with logging off. This suppresses the inclusion of stack-trace related code that depends on Windows API calls that are not available to UWP and thus trigger app certification failures.

Relates to:
- https://github.com/Esri/abseil-cpp/pull/3
- https://github.com/Esri/protobuf/pull/27

[vTest (3rdparty all targets/platforms)](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1317/downstreambuildview/)